### PR TITLE
Fixed fatal error if product is missing.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.0.2 - 2020-07-22 =
+* Fixed fatal error if product is missing.
+
 = 1.0.1 - 2020-05-25 =
 * Added support for Composer.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "title": "sale-percentage",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Manages and displays sale percentage labels.",
   "author": {
     "name": "netzstrategen",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 // phpcs:disable
 /*
   Plugin Name: Sale Percentage
-  Version: 1.0.1
+  Version: 1.0.2
   Text Domain: sale-percentage
   Description: Manages and displays sale percentage labels.
   Author: netzstrategen

--- a/src/SalePercentage.php
+++ b/src/SalePercentage.php
@@ -35,11 +35,10 @@ class SalePercentage {
    * @implements updated_post_meta
    */
   public static function updateSalePercentage($meta_id, $object_id, $meta_key, $meta_value) {
-    if (!static::priceFieldsUpdated($meta_key)) {
+    if (!static::priceFieldsUpdated($meta_key) || !$product = wc_get_product($object_id)) {
       return;
     }
 
-    $product = wc_get_product($object_id);
     if ($product->get_type() === 'variation') {
       $parent_product_id = $product->get_parent_id();
       static::saveSalePercentage($parent_product_id, get_post($parent_product_id));
@@ -64,11 +63,10 @@ class SalePercentage {
    * @implements deleted_post_meta
    */
   public static function deleteSalePercentage($meta_id, $object_id, $meta_key, $meta_value) {
-    if (!static::priceFieldsUpdated($meta_key)) {
+    if (!static::priceFieldsUpdated($meta_key) || !$product = wc_get_product($object_id)) {
       return;
     }
 
-    $product = wc_get_product($object_id);
     if ($product->get_type() === 'variation') {
       $parent_product_id = $product->get_parent_id();
       static::saveSalePercentage($parent_product_id, get_post($parent_product_id));


### PR DESCRIPTION
It's not always given, that the product exists when the related hooks are run. Therefore adding a check if the product exists should resolve the issue.

This issue especially occurred when using WPAI to import products which not exist during import time.